### PR TITLE
chore: add Claude Code configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test*)",
+      "Bash(npm run*)",
+      "Bash(npx*)",
+      "Bash(git*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch"
+    ]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -1,0 +1,19 @@
+---
+name: Claude Task
+about: Create a task for Claude to implement
+labels: claude
+---
+
+## Description
+
+<!-- A clear description of what you want Claude to implement or fix. -->
+
+## Acceptance Criteria
+
+<!-- Define what "done" looks like. Be specific. -->
+
+- [ ] 
+
+## Technical Notes
+
+<!-- Optional: architecture hints, constraints, files to look at, or things to avoid. -->

--- a/.github/REVIEW.md
+++ b/.github/REVIEW.md
@@ -1,0 +1,21 @@
+# Code Review Guidelines
+
+## What to Check
+
+- **Tests**: New endpoints and features must have corresponding tests
+- **Secrets**: Ensure no API keys, tokens, or credentials are committed
+- **Error handling**: Verify errors are handled gracefully and consistently
+- **Early returns**: Prefer early returns over deeply nested conditionals
+- **Naming**: Variables, functions, and files should have clear, descriptive names
+
+## Review Tone
+
+- Be constructive and specific — suggest improvements, don't just point out problems
+- Ask questions when intent is unclear rather than assuming
+- Acknowledge good work and thoughtful solutions
+
+## What to Skip
+
+- Auto-generated files (lock files, build output, codegen)
+- Formatting-only changes handled by automated tools
+- Bikeshedding on subjective style preferences already covered by linters

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,29 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [labeled]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.label.name == 'claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude"
+          prompt: |
+            ${{ github.event_name == 'issues' && format('Implement the feature described in this issue and create a PR referencing issue #{0}.\n\nIssue title: {1}\n\nIssue body:\n{2}', github.event.issue.number, github.event.issue.title, github.event.issue.body) || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Project Guidelines
+
+## Commit Conventions
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`
+- Keep commits atomic — one logical change per commit
+- Write clear, descriptive commit messages
+
+## Testing
+
+- All new features must include tests
+- All bug fixes must include a regression test
+- Run the full test suite before pushing: `npm test` (or equivalent)
+- Aim for meaningful coverage — test behavior, not implementation details
+
+## Security
+
+- Never commit secrets, API keys, tokens, or credentials
+- Use environment variables or secret management for sensitive values
+- Review dependencies for known vulnerabilities
+
+## Code Style
+
+- Write clean, readable code — favor clarity over cleverness
+- Use consistent naming conventions throughout the project
+- Keep functions small and focused on a single responsibility
+- Remove dead code — don't leave commented-out blocks
+
+## Pull Requests
+
+- PRs should be focused and reasonably sized
+- Include a clear description of what changed and why
+- Reference related issues (e.g., `Closes #123`)
+- Ensure CI passes before requesting review
+
+## Documentation
+
+- Update README and relevant docs when changing user-facing behavior
+- Document public APIs and non-obvious design decisions
+- Keep documentation close to the code it describes


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (`.github/workflows/claude.yml`) for Claude Code integration
  - Triggers on `@claude` mentions in issue/PR comments
  - Triggers on issues labeled `claude` to auto-implement and open a PR
- Add project guidelines (`CLAUDE.md`)
- Add code review guidelines (`.github/REVIEW.md`)
- Add Claude permissions config (`.claude/settings.json`)
- Add Claude Task issue template (`.github/ISSUE_TEMPLATE/claude-task.md`)
- Create `claude` label

## Setup Required

After merging, ensure the org-level secret is set:
```
gh secret set ANTHROPIC_API_KEY --org anokye-labs --visibility all
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/akwaaba/pull/465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
